### PR TITLE
Ignore hidden posts when opening all links/comments

### DIFF
--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -22,8 +22,8 @@ function isNSFW(url){
 chrome.extension.onRequest.addListener(function(request, sender, callback) {
 	switch (request.action) {
 		case 'openRedditLinks':
-			jquery_set_links = $("#siteTable a.title");
-			jquery_set_comments = $("#siteTable a.comments");
+			jquery_set_links = $("#siteTable a.title:visible");
+			jquery_set_comments = $("#siteTable a.comments:visible");
 
 			var data = Array();
 


### PR DESCRIPTION
F7U12-Link-Opener opens all posts' links/comments on a page, even if they've been hidden by other extensions (RES) or CSS (custom user stylesheets).

With this change, F7U12-Link-Opener no longer opens links from posts which are hidden.
