### PR TITLE
Don't open comments link if duplicate

### DIFF
--- a/src/backgroundpageScript.js
+++ b/src/backgroundpageScript.js
@@ -90,7 +90,7 @@
 							selected : false
 						});
 
-						if(opencomments) {
+						if(opencomments && url[1] !== url[2]) {
 							chrome.tabs.create({
 								url : url[2],
 								selected : false


### PR DESCRIPTION
There's no point opening up the comments AGAIN if it's the same as the main link